### PR TITLE
Code suggestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,11 +6,108 @@ version = 4
 name = "abac"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "serde",
  "serde_json",
  "thiserror",
  "toml",
 ]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "equivalent"
@@ -25,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +136,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -45,6 +154,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "proc-macro2"
@@ -110,6 +225,12 @@ checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -181,6 +302,85 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "4.5.34", features = ["derive"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"

--- a/res/config.toml
+++ b/res/config.toml
@@ -1,0 +1,4 @@
+[resources]
+"/" = {access_rule = "(if (eq $role admin) (list all) (list))", description = "Root"}
+"/test" = {access_rule = "(list read)"}
+"/private/:user_id" = {access_rule = "(list create)", description = "User space"}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,15 @@
-use crate::resource::ResourceAttributes;
+use crate::resource::Attributes;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Config {
-    pub resources: std::collections::HashMap<String, ResourceAttributes>,
+    pub resources: std::collections::HashMap<String, Attributes>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resource::ResourceAttributes;
+    use crate::resource::Attributes;
     use crate::rule::Rule;
     use std::str::FromStr;
     use toml;
@@ -25,7 +25,7 @@ mod tests {
         let right: Result<Config, toml::de::Error> = Ok(Config {
             resources: std::collections::HashMap::from_iter(vec![(
                 "/".to_string(),
-                ResourceAttributes {
+                Attributes {
                     access_rule: Some(Rule::from_str("()").unwrap()),
                     description: Some("Root".to_string()),
                 },
@@ -45,21 +45,21 @@ mod tests {
             resources: std::collections::HashMap::from_iter(vec![
                 (
                     "/".to_string(),
-                    ResourceAttributes {
+                    Attributes {
                         access_rule: Some(Rule::from_str("()").unwrap()),
                         description: Some("Root".to_string()),
                     },
                 ),
                 (
                     "/dataplatform/".to_string(),
-                    ResourceAttributes {
+                    Attributes {
                         access_rule: Some(Rule::from_str("()").unwrap()),
                         description: Some("Root".to_string()),
                     },
                 ),
                 (
                     "/dataplatform".to_string(),
-                    ResourceAttributes {
+                    Attributes {
                         access_rule: Some(Rule::from_str("()").unwrap()),
                         description: Some("Root".to_string()),
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,11 @@ pub mod rule;
 
 #[cfg(test)]
 mod tests {
-    use crate::{config::Config, resource::ResourceHierarchy};
+    use crate::{config::Config, resource::Hierarchy};
 
     #[test]
     fn main_test() {
-        <Config as TryInto<ResourceHierarchy>>::try_into(
+        <Config as TryInto<Hierarchy>>::try_into(
             toml::from_str::<Config>(
                 r#"
             [resources]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,51 @@
 use abac::{
     config::Config,
     permission::Operation,
-    resource::{ResourceHierarchy, ResourcePath},
+    resource::{Hierarchy, Path},
     rule::Context,
 };
-use std::str::FromStr;
+use clap::Parser;
+use std::{fs, io, path::PathBuf, str::FromStr};
 
-fn main() {
-    let rh = <Config as TryInto<ResourceHierarchy>>::try_into(
-        toml::from_str::<Config>(
-            r#"
-                [resources]
-                "/" = {access_rule = "(if (eq $role admin) (list all) (list))", description = "Root"}
-                "/test" = {access_rule = "(list read)"}
-                "/private/:user_id" = {access_rule = "(list create)", description = "User space"}
-            "#,
-        )
-        .unwrap(),
-    )
-    .unwrap();
+/// ABAC CLI
+#[derive(Parser)]
+struct Args {
+    /// Path to the configuration file
+    #[arg(short, long, default_value = None)]
+    config: Option<PathBuf>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+    #[error("TOML error: {0}")]
+    TomlDe(#[from] toml::de::Error),
+    #[error("No configuration file")]
+    NoConf,
+    #[error("Resource error: {0}")]
+    Resource(#[from] abac::resource::Error),
+    #[error("Rule error: {0}")]
+    Rule(#[from] abac::rule::Error),
+}
+
+fn main() -> Result<(), Error> {
+    let Some(config) = Args::parse().config else {
+        return Err(Error::NoConf);
+    };
+
+    let rh =
+        <Config as TryInto<Hierarchy>>::try_into(toml::from_str(&fs::read_to_string(&config)?)?)?;
 
     println!(
         "{}",
         rh.is_allowed(
             Operation::Create,
-            &mut ResourcePath::from_str("/private/2").unwrap(),
-            &Context::from_str("user_id:1,role:admin").unwrap()
+            &mut Path::from_str("/private/2")?,
+            &Context::from_str("user_id:1,role:admin")?,
         )
         .unwrap()
     );
+
+    Ok(())
 }

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -28,7 +28,7 @@ pub enum Rule {
 }
 
 #[derive(Debug, thiserror::Error, PartialEq)]
-pub enum RuleError {
+pub enum Error {
     #[error("Cannot parse '{0}'")]
     CannotParse(String),
     #[error("Cannot parse '{1}' as {0:?}")]
@@ -55,13 +55,17 @@ pub enum RuleError {
 pub struct Context(Vec<(String, Rule)>);
 
 impl Context {
-    pub fn get(&self, key: &str) -> Result<&Rule, RuleError> {
-        self.0.iter().find(|(k, _)| k == key).map(|(_, v)| v).ok_or(RuleError::KeyNotInContext(key.to_string()))
+    pub fn get(&self, key: &str) -> Result<&Rule, Error> {
+        self.0
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v)
+            .ok_or(Error::KeyNotInContext(key.to_string()))
     }
 }
 
 impl FromStr for Context {
-    type Err = RuleError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut context = Context(Vec::new());
@@ -70,8 +74,8 @@ impl FromStr for Context {
                 continue;
             }
             let mut iter = pair.split(':');
-            let key = iter.next().ok_or(RuleError::CannotParse(String::from(s)))?;
-            let value = iter.next().ok_or(RuleError::CannotParse(String::from(s)))?;
+            let key = iter.next().ok_or(Error::CannotParse(String::from(s)))?;
+            let value = iter.next().ok_or(Error::CannotParse(String::from(s)))?;
             context
                 .0
                 .push((String::from(key), Rule::from_literal(value)?));
@@ -81,7 +85,7 @@ impl FromStr for Context {
 }
 
 impl FromStr for Rule {
-    type Err = RuleError;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse_rule(s)
@@ -101,15 +105,15 @@ impl<'a> Deserialize<'a> for Rule {
     }
 }
 
-fn parse_rule(rule: &str) -> Result<Rule, RuleError> {
+fn parse_rule(rule: &str) -> Result<Rule, Error> {
     let mut stack = vec![Rule::Tuple(Vec::new())];
     let mut buffer = String::new();
-    let flush_buffer = |buffer: &mut String, stack: &mut Vec<Rule>| -> Result<(), RuleError> {
+    let flush_buffer = |buffer: &mut String, stack: &mut Vec<Rule>| -> Result<(), Error> {
         if !buffer.is_empty() {
             let node: Rule;
-            let mut parent = stack.pop().ok_or(RuleError::CannotParse(String::from(rule)))?;
+            let mut parent = stack.pop().ok_or(Error::CannotParse(String::from(rule)))?;
             let Rule::Tuple(ref mut children) = parent else {
-                return Err(RuleError::CannotParse(String::from(rule)));
+                return Err(Error::CannotParse(String::from(rule)));
             };
 
             if buffer.parse::<i32>().is_ok()
@@ -157,40 +161,40 @@ fn parse_rule(rule: &str) -> Result<Rule, RuleError> {
             stack.push(node);
         } else if c == ')' {
             flush_buffer(&mut buffer, &mut stack)?;
-            let node = stack.pop().ok_or(RuleError::CannotParse(String::from(rule)))?;
-            let mut parent = stack.pop().ok_or(RuleError::CannotParse(String::from(rule)))?;
+            let node = stack.pop().ok_or(Error::CannotParse(String::from(rule)))?;
+            let mut parent = stack.pop().ok_or(Error::CannotParse(String::from(rule)))?;
             if let Rule::Tuple(ref mut children) = parent {
                 children.push(node);
             }
             stack.push(parent);
-        } else if c == ' ' || c == '\n' || c == '\t'{
+        } else if c == ' ' || c == '\n' || c == '\t' {
             flush_buffer(&mut buffer, &mut stack)?;
         } else {
             buffer.push(c);
         }
     }
     if let Rule::Tuple(ref mut children) =
-        stack.pop().ok_or(RuleError::CannotParse(String::from(rule)))?
+        stack.pop().ok_or(Error::CannotParse(String::from(rule)))?
     {
-        children.pop().ok_or(RuleError::CannotParse(String::from(rule)))
+        children.pop().ok_or(Error::CannotParse(String::from(rule)))
     } else {
-        Err(RuleError::CannotParse(String::from(rule)))
+        Err(Error::CannotParse(String::from(rule)))
     }
 }
 
 impl Rule {
-    pub fn from_literal(s: &str) -> Result<Rule, RuleError> {
+    pub fn from_literal(s: &str) -> Result<Rule, Error> {
         if s.parse::<i32>().is_ok() {
             Ok(Rule::Integer(s.parse::<i32>().ok().ok_or(
-                RuleError::CannotParseAs(Rule::Integer(0), s.to_string()),
+                Error::CannotParseAs(Rule::Integer(0), s.to_string()),
             )?))
         } else if s.parse::<f32>().is_ok() {
             Ok(Rule::Float(s.parse::<f32>().ok().ok_or(
-                RuleError::CannotParseAs(Rule::Float(0.0), s.to_string()),
+                Error::CannotParseAs(Rule::Float(0.0), s.to_string()),
             )?))
         } else if s.parse::<bool>().is_ok() {
             Ok(Rule::Bool(s.parse::<bool>().ok().ok_or(
-                RuleError::CannotParseAs(Rule::Bool(false), s.to_string()),
+                Error::CannotParseAs(Rule::Bool(false), s.to_string()),
             )?))
         } else {
             Ok(Rule::String(s.to_string()))
@@ -198,49 +202,49 @@ impl Rule {
     }
 
     #[allow(clippy::too_many_lines)] // Prolly a way to improve it but ¯\_(ツ)_/¯
-    pub fn eval(&self, context: &Context) -> Result<Rule, RuleError> {
+    pub fn eval(&self, context: &Context) -> Result<Rule, Error> {
         match self {
             Rule::Tuple(children) => match children.first() {
                 Some(Rule::If(_)) => {
                     if children.len() != 4 {
-                        return Err(RuleError::InvalidIfStatement(self.clone()));
+                        return Err(Error::InvalidIfStatement(self.clone()));
                     }
                     let condition = children
                         .get(1)
-                        .ok_or(RuleError::InvalidIfStatement(self.clone()))?
+                        .ok_or(Error::InvalidIfStatement(self.clone()))?
                         .eval(context)?;
                     let then = children
                         .get(2)
-                        .ok_or(RuleError::InvalidIfStatement(self.clone()))?
+                        .ok_or(Error::InvalidIfStatement(self.clone()))?
                         .eval(context)?;
                     let otherwise = children
                         .get(3)
-                        .ok_or(RuleError::InvalidIfStatement(self.clone()))?
+                        .ok_or(Error::InvalidIfStatement(self.clone()))?
                         .eval(context)?;
                     match condition {
                         Rule::Bool(false) => Ok(otherwise),
                         Rule::Bool(true) => Ok(then),
-                        _ => Err(RuleError::InvalidIfCondition(condition)),
+                        _ => Err(Error::InvalidIfCondition(condition)),
                     }
                 }
                 Some(Rule::Eq(_)) => {
                     if children.len() != 3 {
-                        return Err(RuleError::InvalidEqStatement(self.clone()));
+                        return Err(Error::InvalidEqStatement(self.clone()));
                     }
                     let left = children
                         .get(1)
-                        .ok_or(RuleError::InvalidEqStatement(self.clone()))?
+                        .ok_or(Error::InvalidEqStatement(self.clone()))?
                         .eval(context)?;
                     let right = children
                         .get(2)
-                        .ok_or(RuleError::InvalidEqStatement(self.clone()))?
+                        .ok_or(Error::InvalidEqStatement(self.clone()))?
                         .eval(context)?;
                     match (left, right) {
                         (Rule::String(l), Rule::String(r)) => Ok(Rule::Bool(l == r)),
                         (Rule::Integer(l), Rule::Integer(r)) => Ok(Rule::Bool(l == r)),
                         (Rule::Float(l), Rule::Float(r)) => Ok(Rule::Bool((l - r).abs() < 0.1)), // Adjust tolerance
                         (Rule::Bool(l), Rule::Bool(r)) => Ok(Rule::Bool(l == r)),
-                        (l, r) => Err(RuleError::CannotCompare(l, r)),
+                        (l, r) => Err(Error::CannotCompare(l, r)),
                     }
                 }
                 Some(Rule::List(_)) => Ok(Rule::Tuple(
@@ -248,53 +252,53 @@ impl Rule {
                         .iter()
                         .skip(1)
                         .map(|child| child.eval(context))
-                        .collect::<Result<Vec<Rule>, RuleError>>()?,
+                        .collect::<Result<Vec<Rule>, Error>>()?,
                 )),
                 Some(Rule::And(_)) => {
                     if children.len() != 3 {
-                        return Err(RuleError::InvalidAndStatement(self.clone()));
+                        return Err(Error::InvalidAndStatement(self.clone()));
                     }
                     let left = children
                         .get(1)
-                        .ok_or(RuleError::InvalidAndStatement(self.clone()))?
+                        .ok_or(Error::InvalidAndStatement(self.clone()))?
                         .eval(context)?;
                     let right = children
                         .get(2)
-                        .ok_or(RuleError::InvalidAndStatement(self.clone()))?
+                        .ok_or(Error::InvalidAndStatement(self.clone()))?
                         .eval(context)?;
                     match (left, right) {
                         (Rule::Bool(l), Rule::Bool(r)) => Ok(Rule::Bool(l && r)),
-                        (l, r) => Err(RuleError::CannotCompare(l, r)),
+                        (l, r) => Err(Error::CannotCompare(l, r)),
                     }
                 }
                 Some(Rule::Or(_)) => {
                     if children.len() != 3 {
-                        return Err(RuleError::InvalidOrStatement(self.clone()));
+                        return Err(Error::InvalidOrStatement(self.clone()));
                     }
                     let left = children
                         .get(1)
-                        .ok_or(RuleError::InvalidOrStatement(self.clone()))?
+                        .ok_or(Error::InvalidOrStatement(self.clone()))?
                         .eval(context)?;
                     let right = children
                         .get(2)
-                        .ok_or(RuleError::InvalidOrStatement(self.clone()))?
+                        .ok_or(Error::InvalidOrStatement(self.clone()))?
                         .eval(context)?;
                     match (left, right) {
                         (Rule::Bool(l), Rule::Bool(r)) => Ok(Rule::Bool(l || r)),
-                        (l, r) => Err(RuleError::CannotCompare(l, r)),
+                        (l, r) => Err(Error::CannotCompare(l, r)),
                     }
                 }
                 Some(Rule::In(_)) => {
                     if children.len() != 3 {
-                        return Err(RuleError::InvalidInStatement(self.clone()));
+                        return Err(Error::InvalidInStatement(self.clone()));
                     }
                     let left = children
                         .get(1)
-                        .ok_or(RuleError::InvalidInStatement(self.clone()))?
+                        .ok_or(Error::InvalidInStatement(self.clone()))?
                         .eval(context)?;
                     let right = children
                         .get(2)
-                        .ok_or(RuleError::InvalidInStatement(self.clone()))?
+                        .ok_or(Error::InvalidInStatement(self.clone()))?
                         .eval(context)?;
                     match (left, right) {
                         (Rule::String(l), Rule::Tuple(ref r)) => {
@@ -309,7 +313,7 @@ impl Rule {
                         (Rule::Bool(l), Rule::Tuple(ref r)) => {
                             Ok(Rule::Bool(r.contains(&Rule::Bool(l))))
                         }
-                        (_, _) => Err(RuleError::InvalidInStatement(self.clone())),
+                        (_, _) => Err(Error::InvalidInStatement(self.clone())),
                     }
                 }
                 _ => Ok(Rule::Tuple(vec![])),
@@ -422,10 +426,10 @@ mod tests {
 
     #[test]
     fn test_parse_rule_err() {
-        assert_eq!(Rule::from_str(""), Err(RuleError::CannotParse(String::new())));
+        assert_eq!(Rule::from_str(""), Err(Error::CannotParse(String::new())));
         assert_eq!(
             Rule::from_str("(if (eq )) (list create) (list))"),
-            Err(RuleError::CannotParse(
+            Err(Error::CannotParse(
                 "(if (eq )) (list create) (list))".to_string()
             ))
         );
@@ -440,13 +444,15 @@ mod tests {
             Ok(Rule::Bool(false))
         );
         assert_eq!(
-            Rule::from_str("(
+            Rule::from_str(
+                "(
                 in 10 (
                     list
                 )
-            )")
-                .unwrap()
-                .eval(&Context::from_str("").unwrap()),
+            )"
+            )
+            .unwrap()
+            .eval(&Context::from_str("").unwrap()),
             Ok(Rule::Bool(false))
         );
         assert_eq!(
@@ -480,7 +486,7 @@ mod tests {
             Rule::from_str("(in john jane)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidInStatement(Rule::Tuple(vec![
+            Err(Error::InvalidInStatement(Rule::Tuple(vec![
                 Rule::In(String::from("in")),
                 Rule::String(String::from("john")),
                 Rule::String(String::from("jane")),
@@ -490,7 +496,7 @@ mod tests {
             Rule::from_str("(in (list john) jane)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidInStatement(Rule::Tuple(vec![
+            Err(Error::InvalidInStatement(Rule::Tuple(vec![
                 Rule::In(String::from("in")),
                 Rule::Tuple(vec![
                     Rule::List(String::from("list")),
@@ -535,7 +541,7 @@ mod tests {
             Rule::from_str("(and true)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidAndStatement(Rule::Tuple(vec![
+            Err(Error::InvalidAndStatement(Rule::Tuple(vec![
                 Rule::And(String::from("and")),
                 Rule::Bool(true),
             ])))
@@ -576,7 +582,7 @@ mod tests {
             Rule::from_str("(or true)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidOrStatement(Rule::Tuple(vec![
+            Err(Error::InvalidOrStatement(Rule::Tuple(vec![
                 Rule::Or(String::from("or")),
                 Rule::Bool(true),
             ])))
@@ -647,7 +653,7 @@ mod tests {
             Rule::from_str("(eq)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidEqStatement(Rule::Tuple(vec![Rule::Eq(
+            Err(Error::InvalidEqStatement(Rule::Tuple(vec![Rule::Eq(
                 String::from("eq")
             ),])))
         );
@@ -655,7 +661,7 @@ mod tests {
             Rule::from_str("(eq john)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidEqStatement(Rule::Tuple(vec![
+            Err(Error::InvalidEqStatement(Rule::Tuple(vec![
                 Rule::Eq(String::from("eq")),
                 Rule::String(String::from("john")),
             ])))
@@ -684,7 +690,7 @@ mod tests {
             Rule::from_str("(if)")
                 .unwrap()
                 .eval(&Context::from_str("").unwrap()),
-            Err(RuleError::InvalidIfStatement(Rule::Tuple(vec![Rule::If(
+            Err(Error::InvalidIfStatement(Rule::Tuple(vec![Rule::If(
                 String::from("if")
             ),])))
         );


### PR DESCRIPTION
- Creation of a general `abac::Error` struct to handle error without `unwrap`
- Renaming several structs like `ResourceAttributes` into `Attributes` in order to rely on the namespace system (if name collision, use `resource::Attributes`)
- Using `clap` because it's fun

The three `///` above the `clap` attributes are read by clap to make the CLI doc. So, this is what you get:
```
❯ cargo r -- --help
ABAC CLI

Usage: abac [OPTIONS]

Options:
  -c, --config <CONFIG>  Path to the configuration file
  -h, --help             Print help
```

I put the resource in a .txt file, I don't know the correct extension. You can use it so:
```
❯ cargo r -- -c res/config.toml
```
Or, of course:
```
❯ cargo r -- --config res/config.toml
```